### PR TITLE
Add Pyrogram session init utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ API_PORT=8001
 Create necessary folders:
 ```bash
 mkdir -p sessions userbot_media
+python init_session.py   # run once to generate the session
 ```
 
 ## Running

--- a/init_session.py
+++ b/init_session.py
@@ -1,0 +1,27 @@
+import os
+from dotenv import load_dotenv
+from pyrogram import Client
+
+load_dotenv()
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+SESSIONS_DIR = os.path.join(BASE_DIR, 'sessions')
+os.makedirs(SESSIONS_DIR, exist_ok=True)
+
+TG_API_ID = int(os.environ['TG_API_ID'])
+TG_API_HASH = os.environ['TG_API_HASH']
+TG_SESSION_NAME = os.environ['TG_SESSION_NAME']
+TG_PHONE_NUMBER = os.getenv('TG_PHONE_NUMBER')
+
+app = Client(
+    TG_SESSION_NAME,
+    api_id=TG_API_ID,
+    api_hash=TG_API_HASH,
+    workdir=SESSIONS_DIR,
+    phone_number=TG_PHONE_NUMBER,
+)
+
+if __name__ == '__main__':
+    app.start()
+    app.stop()
+    print(f'Session initialised at {SESSIONS_DIR}')


### PR DESCRIPTION
## Summary
- create `init_session.py` for initial Pyrogram session creation
- document running the script in README

## Testing
- `python -m py_compile init_session.py userbot.py`


------
https://chatgpt.com/codex/tasks/task_e_68612034dba0832e831552a1fba649c4